### PR TITLE
Removing azure text from terrarium project.

### DIFF
--- a/3-terrarium/README.md
+++ b/3-terrarium/README.md
@@ -20,15 +20,8 @@ The artwork was hand drawn by [Jen Looper](http://jenlooper.com) using Procreate
 
 ## Deploy your Terrarium
 
-You can deploy, or publish your terrarium to the web using Azure Static Web Apps. 
+You can deploy, or publish your terrarium to the web using a free Web hosting platform. Current examples are [Netlify](https://www.netlify.com/) or [GitHub pages](https://pages.github.com/).
 
-1. Fork this repo
-
-2. Press this button
-
-[![Deploy to Azure button](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/?feature.customportal=false&WT.mc_id=academic-13441-cxa#create/Microsoft.StaticApp)
-
-3. Walk through the wizard creating your app. Make sure you set the app root to either be `/solution` or the root of your codebase. There's no API in this app, so don't worry about adding that. A .github folder will be created in your forked repo that will help Azure Static Web Apps' build service build and publish your app to a new URL.
 
 
 


### PR DESCRIPTION
Removing the Deploy instructions that ask students to use Azure in order to deploy their terrarium. I have provided links to Netlify and GitHub pages which are two easy options that they may deploy to.
