### PR TITLE
Updating the quiz answers for English so that checkout AND switch are…

### DIFF
--- a/quiz-app/src/assets/translations/en.json
+++ b/quiz-app/src/assets/translations/en.json
@@ -209,11 +209,11 @@
 						"questionText": "How do you switch to a branch?",
 						"answerOptions": [
 							{
-								"answerText": "git switch [branch-name]",
+								"answerText": "git fetch [branch-name]",
 								"isCorrect": "false"
 							},
 							{
-								"answerText": "git checkout [branch-name]",
+								"answerText": "git checkout [branch-name] OR git switch [branch-name]",
 								"isCorrect": "true"
 							},
 							{


### PR DESCRIPTION
… accepted as a way to "switch" branches in Git.

Git allows switching branches with either the experimental 'switch' command or the 'checkout' command. Currently when taking the Post Lesson quiz, the third question in the Post Lecture quiz asks "How do you switch to a branch". The quiz answers are 'git fetch' 'git switch' or 'git checkout'. If the user chooses switch they are told the answer is incorrect, however both checkout and switch are commonly used commands to "switch" branches in Git. I edited the answers to be 'git fetch', 'git checkout OR git switch', and 'git load'. I noticed this as the original repo marks you incorrect if you choose 'git checkout' but  not 'git switch' our repo has diverged a bit on this lesson.

Other quiz answer translations are needed. Happy to use Google translate or can encourage students to contribute by opening an issue for each.